### PR TITLE
Change StringIdRule into StringIdFinder

### DIFF
--- a/src/KenshiWikiValidator/BaseComponents/ArticleValidatorBase.cs
+++ b/src/KenshiWikiValidator/BaseComponents/ArticleValidatorBase.cs
@@ -103,8 +103,8 @@ namespace KenshiWikiValidator.BaseComponents
 
             // TODO: This is a hack: I should figure out a different way
             // to process the string ids before the rules are ran.
-            var stringIdRule = new StringIdRule(this.itemRepository, this.wikiTitles);
-            stringIdRule.Execute(title, content, articleData);
+            var stringIdFinder = new StringIdFinder(this.itemRepository, this.wikiTitles);
+            stringIdFinder.PopulateStringIds(title, articleData, this.CategoryName);
 
             foreach (var stringId in articleData.StringIds)
             {

--- a/tests/KenshiWikiValidator.Tests/WikiCategories/SharedRules/ContainsBlueprintsSectionRuleTests.cs
+++ b/tests/KenshiWikiValidator.Tests/WikiCategories/SharedRules/ContainsBlueprintsSectionRuleTests.cs
@@ -84,6 +84,8 @@ The [[Blueprints]] for this item can be found at the following locations.
                 {
                     new ContainsBlueprintsSectionRule(itemRepository.Object, titleCache),
                 });
+            validator.Setup(v => v.CategoryName)
+                .Returns("Weapons");
 
             validator.Object.CachePageData("Wakizashi", textToValidate);
             var result = validator.Object.Validate("Wakizashi", textToValidate);


### PR DESCRIPTION
It now takes into consideration the article validator's category to know which template the string id should be pulled from